### PR TITLE
fix elixir 1.18 deprecation warning about charlist

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule SyslogSocket.Mixfile do
      version: "2.0.7",
      language: :erlang,
      erlc_options: [
-       {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
+       {:d, :erlang.list_to_atom(~c"ERLANG_OTP_VERSION_" ++ :erlang.system_info(:otp_release))},
        :deterministic,
        :debug_info,
        :warn_export_vars,


### PR DESCRIPTION
Compiling this project to use it with elixir 1.18, the following deprecation warning is printed

```
warning: using single-quoted strings to represent charlists is deprecated.
    Use ~c"" if you indeed want a charlist or use "" instead.
    You may run "mix format --migrate" to change all single-quoted
    strings to use the ~c sigil and fix this warning.
    │
 12 │        {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
    │                                  ~
    │
    └─ mix.exs:12:34
```

This fixes the warning by using the `~c` sigil as suggested